### PR TITLE
Fix passing through exception in the consumer

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -69,7 +69,7 @@ class Consumer extends Request
                 return true;
             }
 
-            throw new \Exception($e);
+            throw $e;
         }
 
         return true;


### PR DESCRIPTION
By throwing a new exception the existing exception will be stringified. As a result, you can't use try/catch statements for e.g. `AMQPTimeoutException`. This should fix it.