### PR TITLE
Add SSL options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ return [
             'exchange'            => 'amq.topic',
             'exchange_type'       => 'topic',
             'consumer_tag'        => 'consumer',
+            'ssl_options'         => [], // See https://secure.php.net/manual/en/context.ssl.php
+            'connect_options'     => [], // See https://github.com/php-amqplib/php-amqplib/blob/master/PhpAmqpLib/Connection/AMQPSSLConnection.php
             'queue_properties'    => ['x-ha-policy' => ['S', 'all']],
             'exchange_properties' => [],
             'timeout'             => 0

--- a/config/amqp.php
+++ b/config/amqp.php
@@ -29,6 +29,8 @@ return [
             'consumer_tag'        => 'consumer',
             'queue_properties'    => ['x-ha-policy' => ['S', 'all']],
             'exchange_properties' => [],
+            'connect_options'     => [],
+            'ssl_options'         => [],
             'timeout'             => 0
         ],
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Config\Repository;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AMQPSSLConnection;
 use PhpAmqpLib\Channel\AMQPChannel;
 
 /**
@@ -30,12 +31,14 @@ class Request extends Context
      */
     public function connect()
     {
-        $this->connection = new AMQPStreamConnection(
+        $this->connection = new AMQPSSLConnection(
             $this->getProperty('host'),
             $this->getProperty('port'),
             $this->getProperty('username'),
             $this->getProperty('password'),
-            $this->getProperty('vhost')
+            $this->getProperty('vhost'),
+            $this->getProperty('ssl_options'),
+            $this->getProperty('connect_options')
         );
 
         $this->channel = $this->connection->channel();


### PR DESCRIPTION
I added the ability to connect to a RabbitMQ server over SSL.

If the`ssl_options` parameter is an empty array, php-amqplib automatically falls back to a 'normal' connection.