### PR TITLE
Change support for ack and reject to have a instance of AMQPMessage

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -3,6 +3,7 @@
 use Illuminate\Config\Repository;
 use Closure;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Message\AMQPMessage;
 
 /**
  * @author Björn Schmitt <code@bjoern.io>
@@ -79,9 +80,9 @@ class Consumer extends Request
     /**
      * Acknowledges a message
      *
-     * @param Message $message
+     * @param AMQPMessage $message
      */
-    public function acknowledge($message)
+    public function acknowledge(AMQPMessage $message)
     {
         $message->delivery_info['channel']->basic_ack($message->delivery_info['delivery_tag']);
 
@@ -93,10 +94,10 @@ class Consumer extends Request
     /**
      * Rejects a message and requeues it if wanted (default: false)
      *
-     * @param Message $message
+     * @param AMQPMessage $message
      * @param bool    $requeue
      */
-    public function reject($message, $requeue = false)
+    public function reject(AMQPMessage $message, $requeue = false)
     {
         $message->delivery_info['channel']->basic_reject($message->delivery_info['delivery_tag'], $requeue);
     }


### PR DESCRIPTION
Hello,

We have notice that in consumer we got a AMQPMessage but when we need to fire ack/nack we should fire Message and this is not consistent.

Could you please review it :) @bschmitt 