### PR TITLE
Use built-in close-on-destruct method on connection

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -107,7 +107,7 @@ class Request extends Context
             );
         }
         // clear at shutdown
-        register_shutdown_function([get_class(), 'shutdown'], $this->channel, $this->connection);
+        $this->connection->set_close_on_destruct(true);
     }
 
     /**


### PR DESCRIPTION
Instead of relying on shutdown functions, use the built-in `set_close_on_destruct` method on the connection. This method closes the connection in a safe way.

Using a shutdown function and calling close on the channel and connection is problematic when the server closes the connection (or there is a problem with the network connection. In that case, the following will happen:

* The application will shut down because the connection is lost.
* The registered shutdown function will be called.
* The `shutdown` method in `Request` will call `close` on the channel and the connection.
* These are already closed, causing an exception to be thrown.
* When exceptions are thrown in shutdown functions, nothing is able to handle them. This causes a fatal error instead.
* No other shutdown functions will be able to run as the execution will abruptly stop when the fatal error occurs.

Letting `php-amqplib` close the connection solves this problem as it does it in a safe way, without throwing exceptions.