### PR TITLE
#60 Re-order AMQPStreamConnection ctor args

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -53,11 +53,13 @@ class Request extends Context
                 $this->getConnectOption('login_method', 'AMQPLAIN'),
                 $this->getConnectOption('login_response', null),
                 $this->getConnectOption('locale', 3),
-                $this->getConnectOption('channel_rpc_timeout', 0.0),
+                $this->getConnectOption('connection_timeout', 3.0),
                 $this->getConnectOption('read_write_timeout', 130),
                 $this->getConnectOption('context', null),
                 $this->getConnectOption('keepalive', false),
-                $this->getConnectOption('heartbeat', 60)
+                $this->getConnectOption('heartbeat', 60),
+                $this->getConnectOption('channel_rpc_timeout', 0.0),
+                $this->getConnectOption('ssl_protocol', null)
             );
         }
 


### PR DESCRIPTION
Remove extra arguments from the AMQPStreamConnection constructor call and get the ones that are left in the correct order.