### PR TITLE
array_key_exists() expects parameter 2 to be array, null given in Con…

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -62,7 +62,7 @@ abstract class Context
      */
     public function getProperty($key)
     {
-        return array_key_exists($key, $this->properties) ? $this->properties[$key] : null;
+        return array_key_exists($key, $this->properties) ? $this->properties[$key] : [];
     }
 
     /**


### PR DESCRIPTION
…text.php line 76

Bugfix
array_key_exists() expects parameter 2 to be array, null given in Context.php line 76