### PR TITLE
Always operate in blocking mode

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -70,9 +70,7 @@ class Consumer extends Request
 
             // consume
             while (count($this->getChannel()->callbacks)) {
-                $this->getChannel()->wait(
-                    null,
-                    !$this->getProperty('blocking'),
+                $this->getChannel()->wait(null, false,
                     $this->getProperty('timeout') ? $this->getProperty('timeout') : 0
                 );
             }


### PR DESCRIPTION
Due to changes in php-amqplib/php-amqplib#642, non-blocking mode does not use a timeout, which results in an infinite loop and high CPU.

This change ensures that only blocking mode is used.

Fixes #63

Also see php-amqplib/php-amqplib#729