### PR TITLE
using Config Repository contract to allow custom config repositories in Context

### DIFF
--- a/src/Context.php
+++ b/src/Context.php
@@ -2,7 +2,7 @@
 
 namespace Bschmitt\Amqp;
 
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 
 /**
  * @author Björn Schmitt <code@bjoern.io>


### PR DESCRIPTION
Current implementation does not allow using custom config repositories so I made a small change to use Contract instead.