### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Amqp::consume('queue-name', function ($message, $resolver) {
     var_dump($message->body);
     $resolver->acknowledge($message);
 }, [
+    'routing' => '',
     'exchange' => 'amq.fanout',
     'exchange_type' => 'fanout',
     'queue_force_declare' => true,


### PR DESCRIPTION
You MUST provide at least one `routing` parameter to consume messages from fanout exchange, as the library creates one bind for each `routing`.