### PR TITLE
Enable PHP 8 Support with php-amqplib 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: php
  
 php:
-  - 7.0
-  - 7.1
-  - 7.2
   - 7.3
   - 7.4
+  - 8.0
  
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -25,9 +25,9 @@
     }
   ],
   "require": {
-    "php": ">=7.0",
-    "php-amqplib/php-amqplib": ">=2.9",
-    "illuminate/support": ">=v5.5.28"
+    "php": "^7.3|~8.0.0",
+    "php-amqplib/php-amqplib": "^3.0",
+    "illuminate/support": ">=6.20.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
**NEED TESTS**

PHP 8.0 support upgrading php-amqplib to 3.0
Drop support for Laravel 5 (EOL)
Fixed support to last Laravel 6 (LTS)