### PR TITLE
Pass in messageData message container not entire array

### DIFF
--- a/src/Amqp.php
+++ b/src/Amqp.php
@@ -79,7 +79,7 @@ class Amqp
 
         foreach(self::$batchMessages as $messageData) {
             if (is_string($messageData['message'])) {
-                $messageData['message'] = new Message($messageData, ['content_type' => 'text/plain', 'delivery_mode' => 2]);
+                $messageData['message'] = new Message($messageData['message'], ['content_type' => 'text/plain', 'delivery_mode' => 2]);
             }
 
             $publisher->batchBasicPublish($messageData['routing'], $messageData['message']);


### PR DESCRIPTION
Fixed creating the AMQP message, originally passing in the $messageData array but should only be the string body. Updated to pass in $messageData['message']