### PR TITLE
Add check connection function.

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -13,7 +13,7 @@ class Request extends Context
 {
 
     /**
-     * @var AMQPStreamConnection
+     * @var ?AMQPStreamConnection
      */
     protected $connection;
 
@@ -158,6 +158,15 @@ class Request extends Context
             return $this->queueInfo[1];
         }
         return 0;
+    }
+
+    /**
+     * Check if connection already exists
+     * @return bool
+     */
+    public function isConnected() : bool
+    {
+        return empty($this->connection);
     }
 
     /**


### PR DESCRIPTION
Added opportunity to check existing connection in \Bschmitt\Amqp\Request.

For example, if you publish messages in loop and don`t want to create a new connection every time, you may check existing one.

usage example
```
    public function __construct(
        private \Bschmitt\Amqp\Publisher $publisher
    )
    {
    }
    
    // usage in methods
   if (!$this->publisher->isConnected()) {
         $this->publisher->connect();
   }
```